### PR TITLE
Fjern Money Abusing Events

### DIFF
--- a/resources/[vrp]/vrp_bilskrot/server.lua
+++ b/resources/[vrp]/vrp_bilskrot/server.lua
@@ -50,7 +50,13 @@ RegisterServerEvent("scrap:SellVehicle")
 AddEventHandler("scrap:SellVehicle", function(vehPrice)
 	local user_id = vRP.getUserId({source})
 	local player = vRP.getUserSource({user_id})
-    vRP.giveBankMoney({user_id,vehPrice})
+	for k,v in ipairs(groups) do
+		if vRP.hasGroup({user_id,v}) then
+    			vRP.giveBankMoney({user_id,vehPrice})
+		else
+			print(GetPlayerName(player) .. "(".. user_id ..") triggerede et money event uden at være mekaniker, er nok en modder.")
+		end
+	end
 end)
 
 RegisterServerEvent('scrap:Mechanic')

--- a/resources/[vrp]/vrp_bilskrot/server.lua
+++ b/resources/[vrp]/vrp_bilskrot/server.lua
@@ -52,7 +52,11 @@ AddEventHandler("scrap:SellVehicle", function(vehPrice)
 	local player = vRP.getUserSource({user_id})
 	for k,v in ipairs(groups) do
 		if vRP.hasGroup({user_id,v}) then
-    			vRP.giveBankMoney({user_id,vehPrice})
+			if tonumber(vehPrice) <= 11000 then
+    				vRP.giveBankMoney({user_id,vehPrice})
+			else
+				print(GetPlayerName(source) .. "(".. user_id ..") prøvede at give flere penge end man kan få fra jobbet, er nok en modder.")
+			end
 		else
 			print(GetPlayerName(player) .. "(".. user_id ..") triggerede et money event uden at være mekaniker, er nok en modder.")
 		end

--- a/resources/[vrp]/vrp_scrapyard/server.lua
+++ b/resources/[vrp]/vrp_scrapyard/server.lua
@@ -22,7 +22,11 @@ AddEventHandler('scrapyard:payMeNow', function(amount)
 	local source = source
 	local user_id = vRP.getUserId({source})
 	if vRP.hasPermission({user_id,"repair.scrap"}) then
-		vRP.giveBankMoney({user_id,amount})
+		if tonumber(amount) <= 2500 then
+			vRP.giveBankMoney({user_id,amount})
+		else
+			print(GetPlayerName(source) .. "(".. user_id ..") prøvede at give flere penge end man kan få fra jobbet, er nok en modder.")	
+		end
 	else
 		print(GetPlayerName(source) .. "(".. user_id ..") triggerede et money event uden at være mekaniker, er nok en modder.")
 	end

--- a/resources/[vrp]/vrp_scrapyard/server.lua
+++ b/resources/[vrp]/vrp_scrapyard/server.lua
@@ -21,7 +21,11 @@ RegisterServerEvent('scrapyard:payMeNow')
 AddEventHandler('scrapyard:payMeNow', function(amount)
 	local source = source
 	local user_id = vRP.getUserId({source})
-	vRP.giveBankMoney({user_id,amount})
+	if vRP.hasPermission({user_id,"repair.scrap"}) then
+		vRP.giveBankMoney({user_id,amount})
+	else
+		print(GetPlayerName(source) .. "(".. user_id ..") triggerede et money event uden at være mekaniker, er nok en modder.")
+	end
 	TriggerClientEvent("pNotify:SendNotification", source,{text = "Modtog <b style='color: #4E9350'>"..amount.." $</b>.", type = "success", queue = "global", timeout = 5000, layout = "centerRight",animation = {open = "gta_effects_fade_in", close = "gta_effects_fade_out"}})
 end)
 


### PR DESCRIPTION
Events der bliver brugt af modders til at spawne så mange penge de vil, set på redEngine discord, hvor et par brugere snakkede om eventsne.